### PR TITLE
Fix uncommit on win32 machines

### DIFF
--- a/lib/uncommit.js
+++ b/lib/uncommit.js
@@ -4,8 +4,7 @@ var exec = require("child_process").exec;
 
 module.exports = function(){
     return new Promise(function(resolve, reject){
-        var head = (process.platform === 'win32') ? "^HEAD" : "HEAD^"
-        exec("git reset --soft " + head, function(err){
+        exec("git reset --soft HEAD^", function(err){
             if(err){
                 reject(err);
             } 


### PR DESCRIPTION
I couldn't get why uncommit didn't work on my machine running this code.

![uncommit_poc_js](https://user-images.githubusercontent.com/18394737/79049201-08643400-7c1a-11ea-94a3-4871ac5ba767.PNG)

Here is the execution result before my fix.

![uncommit_fails_on_windows](https://user-images.githubusercontent.com/18394737/79049148-97bd1780-7c19-11ea-9404-8e43a6e4c257.PNG)

Here is the result after the fix.

![fixed_uncommit](https://user-images.githubusercontent.com/18394737/79049214-1ca83100-7c1a-11ea-9a8a-77526d114d46.PNG)

